### PR TITLE
fix: Fix linting errors due to eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,9 @@ module.exports = {
   plugins: [
   ],
   // add your custom rules here
-  rules: {}
+  rules: {
+    "vue/multi-word-component-names": ["warn", {
+      "ignores": []
+    }]
+  }
 }


### PR DESCRIPTION
problematic rule: vue/multi-word-component-names